### PR TITLE
Updated several files to point to mariadb job rename to standalone

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -3,4 +3,4 @@ blobstore:
   provider: s3
   options:
     bucket_name: mariadb-boshrelease
-final_name: mariadb
+final_name: mariadb-forge

--- a/jobs/mariadb-blacksmith-plans/templates/plans/standalone/credentials.yml
+++ b/jobs/mariadb-blacksmith-plans/templates/plans/standalone/credentials.yml
@@ -16,6 +16,6 @@
 #      host: (( grab jobs.xyzzy/0.ips[0] ))
 #
 credentials:
-  host: (( grab jobs.mariadb/0.ips[0] ))
+  host: (( grab jobs.standalone/0.ips[0] ))
   password: (( grab meta.admin_password ))
   username: (( grab meta.admin_username ))

--- a/jobs/mariadb-blacksmith-plans/templates/plans/standalone/init
+++ b/jobs/mariadb-blacksmith-plans/templates/plans/standalone/init
@@ -2,7 +2,7 @@
 # nothing to do, yet.
 set -eu
 
-safe gen $CREDENTIALS/mariadb/system password
-safe gen $CREDENTIALS/mariadb/system username
+safe gen $CREDENTIALS/standalone/system password
+safe gen $CREDENTIALS/standalone/system username
 
 exit 0

--- a/jobs/mariadb-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/mariadb-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -1,7 +1,7 @@
 meta:
   size: default
-  admin_password: (( vault $CREDENTIALS "/mariadb/system:password" ))
-  admin_username: (( vault $CREDENTIALS "/mariadb/system:username" ))
+  admin_password: (( vault $CREDENTIALS "/standalone/system:password" ))
+  admin_username: (( vault $CREDENTIALS "/standalone/system:username" ))
 
 releases:
   - { name: mariadb-forge, version: latest }

--- a/jobs/standalone/monit
+++ b/jobs/standalone/monit
@@ -1,5 +1,5 @@
-check process mariadb
-  with pidfile /var/vcap/sys/run/mariadb/mariadb.pid
-  start program "/var/vcap/jobs/mariadb/bin/monit_debugger mariadb_ctl '/var/vcap/jobs/mariadb/bin/ctl start'"
-  stop program "/var/vcap/jobs/mariadb/bin/monit_debugger mariadb_ctl '/var/vcap/jobs/mariadb/bin/ctl stop'"
+check process standalone
+  with pidfile /var/vcap/sys/run/standalone/standalone.pid
+  start program "/var/vcap/jobs/standalone/bin/monit_debugger mariadb_ctl '/var/vcap/jobs/standalone/bin/ctl start'"
+  stop program "/var/vcap/jobs/standalone/bin/monit_debugger mariadb_ctl '/var/vcap/jobs/standalone/bin/ctl stop'"
   group vcap

--- a/jobs/standalone/spec
+++ b/jobs/standalone/spec
@@ -1,5 +1,5 @@
 ---
-name: mariadb
+name: standalone
 packages:
   - mariadb
 templates:

--- a/jobs/standalone/templates/bin/ctl.erb
+++ b/jobs/standalone/templates/bin/ctl.erb
@@ -4,7 +4,7 @@ set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
 # Setup env vars and folders for the webapp_ctl script
-source /var/vcap/jobs/mariadb/helpers/ctl_setup.sh 'mariadb'
+source /var/vcap/jobs/standalone/helpers/ctl_setup.sh 'standalone'
 exec >>$LOG_DIR/$JOB_NAME.log 2>&1
 
 export LANG=en_US.UTF-8
@@ -16,7 +16,7 @@ case $1 in
     pid_guard $PIDFILE $JOB_NAME
 
     # where do the configs (my.cnf) live?
-    export MYSQL_HOME=/var/vcap/jobs/mariadb/config
+    export MYSQL_HOME=/var/vcap/jobs/standalone/config
 
     # create the data store
     mkdir -p $DATADIR

--- a/jobs/standalone/templates/config/my.cnf.erb
+++ b/jobs/standalone/templates/config/my.cnf.erb
@@ -3,4 +3,4 @@ port=<%= p('db.port') %>
 basedir=/var/vcap/packages/mariadb
 datadir=/var/vcap/store/mariadb
 bind-address=0.0.0.0
-init_file=/var/vcap/jobs/mariadb/config/mariadb_init
+init_file=/var/vcap/jobs/standalone/config/mariadb_init

--- a/jobs/standalone/templates/helpers/ctl_setup.sh
+++ b/jobs/standalone/templates/helpers/ctl_setup.sh
@@ -57,7 +57,7 @@ done
 export RUN_DIR=/var/vcap/sys/run/$JOB_NAME
 export LOG_DIR=/var/vcap/sys/log/$JOB_NAME
 export TMP_DIR=/var/vcap/sys/tmp/$JOB_NAME
-export STORE_DIR=/var/vcap/store/$JOB_NAME
+export STORE_DIR=/var/vcap/store/mariadb
 for dir in $RUN_DIR $LOG_DIR $TMP_DIR $STORE_DIR
 do
   mkdir -p ${dir}


### PR DESCRIPTION
Mariadb job was renamed to standalone but most of the paths were not updated, so here it is. Also updated release name to `mariadb-forge` to be consistent with redis-forge. 