### PR TITLE
Fixed override of AZ in 'standalone' plan template

### DIFF
--- a/jobs/mariadb-blacksmith-plans/templates/bin/configure-blacksmith
+++ b/jobs/mariadb-blacksmith-plans/templates/bin/configure-blacksmith
@@ -40,6 +40,11 @@ meta:
   size: <%= plan["vm_type"] || 'default' %>
   net:  <%= plan["network"] || 'mariadb-service' %>
   disk: <%= plan["disk"]    || 2_048 %>
+
+<% if plan["azs"] %>
+  azs: <%= plan["azs"] %>
+<% end %>
+
 EOF
 
 

--- a/jobs/mariadb-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/mariadb-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -1,7 +1,7 @@
 meta:
   size: default
   default:
-    az: z1
+    azs: z1
   admin_password: (( vault $CREDENTIALS "/standalone/system:password" ))
   admin_username: (( vault $CREDENTIALS "/standalone/system:username" ))
 
@@ -22,7 +22,7 @@ update:
 instance_groups:
   - name: standalone
     instances: 1
-    azs: [(( grab meta.az || meta.default.az ))]
+    azs: [(( grab meta.azs || meta.default.azs ))]
     networks: [name: (( grab meta.net || "mariadb-service" ))]
     stemcell: default
 


### PR DESCRIPTION
Tested this locally and was able to override the 'z1' designation for the AZ.

Changed the 'az' to 'azs' in the standalone manifest template, in order to be consistent with the way it was done in the other forges.