### PR TITLE
Newline patch

### DIFF
--- a/jobs/mariadb-blacksmith-plans/templates/plans/service.yml
+++ b/jobs/mariadb-blacksmith-plans/templates/plans/service.yml
@@ -1,7 +1,7 @@
 ---
 id:   <%= p('service.id') %>
 name: <%= p('service.name') %>
-description: |
+description: |-
     <%= p('service.description') %>
 tags:
   <% p('service.tags', []).each { |tag| %>  - <%= tag %>


### PR DESCRIPTION
I noticed that the service description has a newline embedded in the string, messing up `cf marketplace`:

```
service      plans                                                description                        broker
mariadb      large-dedicated, medium-dedicated, small-dedicated   A dedicated MariaDB instance.
      blacksmith
```

By adding in the chomping indicator `-` (see: https://yaml-multiline.info/) that new line is not added:

```
service      plans                                                description                        broker
mariadb      large-dedicated, medium-dedicated, small-dedicated   A dedicated MariaDB instance.      blacksmith
```

Yeah, it annoyed me. ;-)