### PR TITLE
Upgrade to MariaDB 10.4.12

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-mariadb/mariadb-10.1.41-linux-x86_64.tar.gz:
-  size: 404513999
-  object_id: ea5b9cd0-244e-4775-5652-89f7d70a14a9
-  sha: dec4baba2a835d8dac37651e92e7dc1b9d5f68e4
+mariadb/mariadb-10.4.12-linux-x86_64.tar.gz:
+  size: 898564385
+  sha: sha256:1dde8ab3b94c1214fb6ff0b08235eafa8083efb2d8aefa444aaf8e41e3bd88ed

--- a/packages/mariadb/packaging
+++ b/packages/mariadb/packaging
@@ -5,10 +5,12 @@ set -u # report the usage of uninitialized variables
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 export HOME=/var/vcap
 
-tar -xvf mariadb/mariadb-10.1.41-linux-x86_64.tar.gz
+export MARIADB="mariadb-10.4.12-linux-x86_64"
+
+tar -xvf mariadb/${MARIADB}.tar.gz
 for x in scripts bin lib share; do
   mkdir -p ${BOSH_INSTALL_TARGET}/${x}
-  cp -a mariadb-10.1.41-linux-x86_64/${x}/* ${BOSH_INSTALL_TARGET}/${x}
+  cp -a ${MARIADB}/${x}/* ${BOSH_INSTALL_TARGET}/${x}
 done
 chmod 0755 ${BOSH_INSTALL_TARGET}/bin/*
 chmod 0755 ${BOSH_INSTALL_TARGET}/scripts/*

--- a/packages/mariadb/spec
+++ b/packages/mariadb/spec
@@ -2,4 +2,4 @@
 name: mariadb
 dependencies: []
 files:
-- mariadb/mariadb-10.1.41-linux-x86_64.tar.gz
+- mariadb/mariadb-10.4.12-linux-x86_64.tar.gz


### PR DESCRIPTION
- Upgrade to MariaDB 10.4.12.
- Also improved the `packages/mariadb/packaging` to use an environment variable to make future changes easier and less error prone.

[Link to the blob](https://downloads.mariadb.org/interstitial/mariadb-10.4.12/bintar-linux-x86_64/mariadb-10.4.12-linux-x86_64.tar.gz)