### PR TITLE
Update MariaDB to 10.4.22 and Bionic Stemcell

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,4 @@
-mariadb/mariadb-10.4.12-linux-x86_64.tar.gz:
-  size: 898564385
-  object_id: 8eba7f43-0cc8-4679-70b8-0dbdb868a624
-  sha: sha256:1dde8ab3b94c1214fb6ff0b08235eafa8083efb2d8aefa444aaf8e41e3bd88ed
+mariadb/mariadb-10.4.22-linux-x86_64.tar.gz:
+  size: 1148661449
+  object_id: eacddf1f-c037-4780-585e-52f91133ce88
+  sha: sha256:e47ee5290ac02756b2a1e4493241e90d10b846c21aa62e4de1869323ca00ede6

--- a/jobs/mariadb-blacksmith-plans/templates/plans/standalone/manifest.yml
+++ b/jobs/mariadb-blacksmith-plans/templates/plans/standalone/manifest.yml
@@ -11,7 +11,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-xenial
+  os: ubuntu-bionic
   version: latest
 
 update:

--- a/packages/mariadb/packaging
+++ b/packages/mariadb/packaging
@@ -5,7 +5,7 @@ set -u # report the usage of uninitialized variables
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 export HOME=/var/vcap
 
-export MARIADB="mariadb-10.4.12-linux-x86_64"
+export MARIADB="mariadb-10.4.22-linux-x86_64"
 
 tar -xvf mariadb/${MARIADB}.tar.gz
 for x in scripts bin lib share; do

--- a/packages/mariadb/spec
+++ b/packages/mariadb/spec
@@ -2,4 +2,4 @@
 name: mariadb
 dependencies: []
 files:
-- mariadb/mariadb-10.4.12-linux-x86_64.tar.gz
+- mariadb/mariadb-10.4.22-linux-x86_64.tar.gz


### PR DESCRIPTION
# Improvements

* Stemcell updated to use Bionic (requires Blacksmith-genesis-kit with Bionic or Bionic stemcell manually uploaded)
* Update MariaDB to 10.4.22